### PR TITLE
pg gem getting installed

### DIFF
--- a/cartodb-rb-client.gemspec
+++ b/cartodb-rb-client.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'i18n', '>= 0.5.0', '<= 0.6.0'
   s.add_dependency 'rgeo', '>= 0.3.2'
   s.add_dependency 'rgeo-geojson', '>= 0.2.1'
-  s.add_dependency 'pg', '0.11.0' if postgresql_installed?
+  s.add_dependency('pg', '0.11.0') if postgresql_installed?
   s.add_dependency 'json', '>= 1.5.3'
 end


### PR DESCRIPTION
I tried installing the gem, but it was failing while trying to install the `pg` gem.  PostGres is not installed.

The `postgresql_installed?` method is correct.  I don't understand why, but putting the parens around the args fixed the issue.

Go figure
