### PR TITLE
sql query example call breaks with trailing comma after options

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -343,7 +343,7 @@ Example:
     10.times{ CartoDB::Connection.insert_row 'table_1', :field1 => 'cartoDB is awesome!'}
 
     # And now, the query itself
-    CartoDB::Connection.query 'SELECT * FROM table_1', :page => 1,
+    CartoDB::Connection.query 'SELECT * FROM table_1', :page => 1
 :rows_per_page => 5
 
 Results:


### PR DESCRIPTION
no trailing comma in query
